### PR TITLE
ENV: Simplify environment by using python:3.10-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,15 @@
-FROM mambaorg/micromamba:1.5.1
-USER root
-
-COPY env.yaml /tmp/env.yaml
-RUN micromamba create -y -f /tmp/env.yaml && \
-	micromamba clean --all --yes
+FROM python:3.10-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-                    bc \
-                    ca-certificates \
-                    curl \
-                    git \
-                    gnupg \
-                    lsb-release \
-                    netbase \
-                    xvfb && \
+        ca-certificates \
+        netbase \
+        && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-
 ENV FLYWHEEL=/flywheel/v0
-WORKDIR ${FLYWHEEL}
-ENV PATH="/opt/conda/envs/wbhi-redcap/bin:$PATH"
 COPY requirements.txt /tmp/requirements.txt
-RUN /opt/conda/envs/wbhi-redcap/bin/pip install --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN mkdir -p ${FLYWHEEL}
 COPY run.py ${FLYWHEEL}/run.py

--- a/env.yaml
+++ b/env.yaml
@@ -1,7 +1,0 @@
-name: wbhi-redcap
-channels:
-  - conda-forge
-  # Update this ~yearly; last updated Feb 2024
-dependencies:
-  - python >=3.10,<3.11
-  

--- a/manifest.json
+++ b/manifest.json
@@ -11,24 +11,11 @@
 	"source": "",
 	"environment": {
 		"FLYWHEEL": "/flywheel/v0",
-		"MAMBA_USER_ID": "57439",
-		"ENV_NAME": "base",
-		"MAMBA_USER": "mambauser",
-		"HOSTNAME": "677a334a253c",
 		"PWD": "/flywheel/v0",
-		"CONDA_PREFIX": "/opt/conda",
-		"MAMBA_ROOT_PREFIX": "/opt/conda",
 		"HOME": "/root",
 		"LANG": "C.UTF-8",
-		"CONDA_PROMPT_MODIFIER": "(base) ",
-		"MAMBA_EXE": "/bin/micromamba",
-		"MAMBA_USER_GID": "57439",
-		"TERM": "xterm",
-		"CONDA_SHLVL": "1",
-		"SHLVL": "1",
-		"CONDA_DEFAULT_ENV": "base",
 		"LC_ALL": "C.UTF-8",
-		"PATH": "/opt/conda/bin:/opt/conda/condabin:/opt/conda/envs/wbhi-redcap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	},
 	"custom": {
 		"gear-builder": {


### PR DESCRIPTION
I'm not sure how often this Docker image needs to be rebuilt, but in case that's ever a bottleneck, here's a simplification.

This drops the image size by ~500MB (80%) and build time by ~40s (83%).